### PR TITLE
refreshing chat after marking spam/ham

### DIFF
--- a/src/main/java/com/jackriccomini/spamfilter/SpamFilterPlugin.java
+++ b/src/main/java/com/jackriccomini/spamfilter/SpamFilterPlugin.java
@@ -185,8 +185,8 @@ public class SpamFilterPlugin extends Plugin
 					.setTarget(ColorUtil.wrapWithColorTag("message", Color.WHITE))
 					.onClick(e -> {
 						markSpam(selectedChat);
+						client.refreshChat();
 					});
-			client.refreshChat();
 		}
 		if (config.showMarkHam()) {
 			client.createMenuEntry(1)
@@ -195,8 +195,8 @@ public class SpamFilterPlugin extends Plugin
 					.setTarget(ColorUtil.wrapWithColorTag("message", Color.WHITE))
 					.onClick(e -> {
 						markHam(selectedChat);
+						client.refreshChat();
 					});
-			client.refreshChat();
 		}
 	}
 

--- a/src/main/java/com/jackriccomini/spamfilter/SpamFilterPlugin.java
+++ b/src/main/java/com/jackriccomini/spamfilter/SpamFilterPlugin.java
@@ -186,6 +186,7 @@ public class SpamFilterPlugin extends Plugin
 					.onClick(e -> {
 						markSpam(selectedChat);
 					});
+			client.refreshChat();
 		}
 		if (config.showMarkHam()) {
 			client.createMenuEntry(1)
@@ -195,6 +196,7 @@ public class SpamFilterPlugin extends Plugin
 					.onClick(e -> {
 						markHam(selectedChat);
 					});
+			client.refreshChat();
 		}
 	}
 


### PR DESCRIPTION
Marking a chat as spam or ham does not update the chatbox until you close and reopen the chatbox calling for a redraw. This PR starts the chatbox redraw as soon as you mark a message as spam/ham.