### PR TITLE
Disable Spam Filter for the Player's Own Messages

### DIFF
--- a/src/main/java/com/jackriccomini/spamfilter/SpamFilterPlugin.java
+++ b/src/main/java/com/jackriccomini/spamfilter/SpamFilterPlugin.java
@@ -246,7 +246,7 @@ public class SpamFilterPlugin extends Plugin
 
 		// Disable spam filtering for the player's own messages
 		if (messageNode != null) {
-			final String senderName = messageNode.getName();
+			final String senderName = Text.removeTags(messageNode.getName());
 			final String displayName = client.getLocalPlayer().getName();
 			if (senderName.equalsIgnoreCase(displayName)) {
 				return;

--- a/src/main/java/com/jackriccomini/spamfilter/SpamFilterPlugin.java
+++ b/src/main/java/com/jackriccomini/spamfilter/SpamFilterPlugin.java
@@ -202,7 +202,13 @@ public class SpamFilterPlugin extends Plugin
 
 	@Subscribe
 	public void onOverheadTextChanged(OverheadTextChanged event) {
-		if (!(event.getActor() instanceof Player) || !config.filterOverheads()) {
+		final String displayName = client.getLocalPlayer().getName();
+		final String senderName = event.getActor().getName();
+		if (!(event.getActor() instanceof Player) ||
+				!config.filterOverheads() ||
+				// Disable spam filtering for the player's own messages
+				(displayName != null && displayName.equalsIgnoreCase(senderName))
+		) {
 			return;
 		}
 		String message = event.getOverheadText();
@@ -237,6 +243,15 @@ public class SpamFilterPlugin extends Plugin
 			return;
 		}
 		final MessageNode messageNode = client.getMessages().get(messageId);
+
+		// Disable spam filtering for the player's own messages
+		if (messageNode != null) {
+			final String senderName = messageNode.getName();
+			final String displayName = client.getLocalPlayer().getName();
+			if (senderName.equalsIgnoreCase(displayName)) {
+				return;
+			}
+		}
 
 		// Overhead message strings already have leading and trailing whitespace stripped but chatbox message strings
 		// do not. If we don't strip whitespace then we will tokenise overhead vs chatbox messages inconsistently and

--- a/src/main/java/com/jackriccomini/spamfilter/SpamFilterPlugin.java
+++ b/src/main/java/com/jackriccomini/spamfilter/SpamFilterPlugin.java
@@ -245,7 +245,7 @@ public class SpamFilterPlugin extends Plugin
 		final MessageNode messageNode = client.getMessages().get(messageId);
 
 		// Disable spam filtering for the player's own messages
-		if (currPlayersMsg(messageNode)) {
+		if (isCurrPlayersMsg(messageNode)) {
 			return;
 		}
 
@@ -274,13 +274,13 @@ public class SpamFilterPlugin extends Plugin
 	}
 
 	/**
-	 * This method determines if the chat message being processed is sent by the currently
-	 * logged-in player. It allows us to disable the chat filter for the player's own messages.
+	 * Determines if the chat message being processed is sent by the currently
+	 * logged-in player. Used to disable the chat filter for the player's own messages.
 	 *
-	 * @param messageNode This is the MessageNode Object that contains information about the chat message.
-	 * @return boolean This returns true if the message is sent by the player. Otherwise false.
+	 * @param messageNode The MessageNode that contains information about the chat message.
+	 * @return boolean true if the message is sent by the player. Otherwise false.
 	 */
-	private boolean currPlayersMsg(MessageNode messageNode) {
+	private boolean isCurrPlayersMsg(MessageNode messageNode) {
 		if (messageNode != null) {
 			final String senderName = Text.removeTags(messageNode.getName());
 			final String displayName = client.getLocalPlayer().getName();

--- a/src/main/java/com/jackriccomini/spamfilter/SpamFilterPlugin.java
+++ b/src/main/java/com/jackriccomini/spamfilter/SpamFilterPlugin.java
@@ -245,12 +245,8 @@ public class SpamFilterPlugin extends Plugin
 		final MessageNode messageNode = client.getMessages().get(messageId);
 
 		// Disable spam filtering for the player's own messages
-		if (messageNode != null) {
-			final String senderName = Text.removeTags(messageNode.getName());
-			final String displayName = client.getLocalPlayer().getName();
-			if (senderName.equalsIgnoreCase(displayName)) {
-				return;
-			}
+		if (currPlayersMsg(messageNode)) {
+			return;
 		}
 
 		// Overhead message strings already have leading and trailing whitespace stripped but chatbox message strings
@@ -275,6 +271,30 @@ public class SpamFilterPlugin extends Plugin
 		}
 		stringStack[stringStackSize - 1] = message;
 
+	}
+
+	/**
+	 * This method determines if the chat message being processed is sent by the currently
+	 * logged-in player. It allows us to disable the chat filter for the player's own messages.
+	 *
+	 * @param messageNode This is the MessageNode Object that contains information about the chat message.
+	 * @return boolean This returns true if the message is sent by the player. Otherwise false.
+	 */
+	private boolean currPlayersMsg(MessageNode messageNode) {
+		if (messageNode != null) {
+			final String senderName = Text.removeTags(messageNode.getName());
+			final String displayName = client.getLocalPlayer().getName();
+
+			if (displayName == null) {
+				return true;
+			}
+
+			// Remove potential differences in encoding of the space character
+			final String normalizedSenderName = senderName.replaceAll("\\h", " ");
+			final String normalizedDisplayName = displayName.replaceAll("\\h", " ");
+			return normalizedSenderName.equalsIgnoreCase(normalizedDisplayName);
+		}
+		return false;
 	}
 
 	float pTokenBad(String token) {


### PR DESCRIPTION
# Description
- Disabled the spam filter (overhead and in the chatbox) for any of the logged-in player's own messages.

Fixes the issue with the spam filter catching the player's own messages, as described by comments in #2, #3, and #8.

## Type of change
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Have done some sanity tests in the RuneLite UI.